### PR TITLE
Add CI and Release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Run Lint
+        run: make lint
+
+      - name: Run Tests
+        run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Docker image tag
+        run: echo "IMAGE_TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+      - name: Build and Push Docker image
+        run: |
+          IMAGE=ghcr.io/${{ github.repository }}:${IMAGE_TAG}
+          make docker-build IMG=$IMAGE
+          make docker-push IMG=$IMAGE
+
+      - name: Generate Installer YAML
+        run: make build-installer
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/install.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🚀 Add CI and Release Workflows

This PR introduces complete CI/CD automation for the project.

### ✅ CI Pipeline (`ci.yml`)
- Runs on push and pull request to `main`
- Sets up Go 1.25
- Executes:
  - `make lint`
  - `make test`
- Ensures PRs fail if linting or tests fail

### 🚀 Release Pipeline (`release.yml`)
Triggered on tag push (`v*`):

- Logs into GHCR
- Builds Docker image using Makefile
- Pushes image to:
  ghcr.io/<owner>/<repo>:<tag>
- Generates installer using `make build-installer`
- Creates GitHub Release
- Attaches `dist/install.yaml` as release asset

### 📌 Note
The repository uses Kustomize and does not contain a Helm chart (`Chart.yaml` not found).
Therefore, the release workflow attaches the generated installer YAML instead.

Close #20